### PR TITLE
Fix outdated AudioSet link, shared memory, and TypeError

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ docker compose run --rm trainer python train.py --wake-word "hey cal" --data-dir
 
 Training takes 4-8 hours depending on GPU.
 
+Don't be alarmed if the finished model is only a few hundred kilobytes. Test your model in the following section to see if it works correctly.
+
 ### 5. Test Your Model
 
 Test on your host machine (needs microphone access):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   kokoro:
     image: ghcr.io/remsky/kokoro-fastapi-gpu:latest
+    ipc: "host"
     ports:
       - "8880:8880"
     deploy:
@@ -13,6 +14,7 @@ services:
 
   trainer:
     build: .
+    ipc: "host"
     deploy:
       resources:
         reservations:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ acoustics==0.2.6
 pronouncing==0.2.0
 datasets==2.14.6
 deep-phonemizer==0.0.19
+protobuf>=3.20.0,<4.0.0
 
 # Data download/processing
 piper-phonemize

--- a/setup-data.sh
+++ b/setup-data.sh
@@ -67,7 +67,7 @@ if [ ! -d "$DATA_DIR/audioset_16k" ]; then
     echo "Downloading AudioSet background audio..."
     mkdir -p "$DATA_DIR/audioset" "$DATA_DIR/audioset_16k"
     curl -L -o "$DATA_DIR/audioset/bal_train09.tar" \
-        'https://huggingface.co/datasets/agkphysics/AudioSet/resolve/main/bal_train09.tar'
+        'https://huggingface.co/datasets/agkphysics/AudioSet/resolve/728fffe80088808b49db5aa700f2e264c035c880/data/bal_train09.tar'
     tar -xf "$DATA_DIR/audioset/bal_train09.tar" -C "$DATA_DIR/audioset"
 
     python3 << EOF


### PR DESCRIPTION
The link for the AudioSet download is now outdated as of October 16th, 2025 with the commit "Convert to Parquet format". See the breaking commit here: https://huggingface.co/datasets/agkphysics/AudioSet/commit/0c609e8302cf139307f639c57652032af0a88041).

I've pinned the link to a specific revision where the `bal_train09.tar` file was still present. I've tested this on my install, and the `setup-data.sh` file works now.

Additionally, when running the `train.py` file, I got an error saying that the container ran out of shared memory. I fixed this by adding `ipc: "host"` to the Docker containers.

I also encountered the following TypeError, so I followed the first outlined method and pinned the `protobuf` package to `3.20.x` in the `requirements.txt` file.
```
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
 ```

When the model finished training, I was originally alarmed to see that the model file was only roughly 400K and I thought there was an error. However, after testing, I could see that it was working as intended. Therefore, I've added a line to the documentation that conveys this more clearly to the reader.

With all these changes, I was able to train my wake word successfully!

Thanks for an amazing project. This is the only project that actually worked to generate a wake word.

Regards.